### PR TITLE
feat: add `mempool-custom-hill-fees` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,44 @@ The functions are deployed on `Vercel`: https://test-lnd-fee-url.vercel.app.
 
 ## APIs
 
-- `/api/mempool-fees`: General conversion from mempool.space fee recommendations to LND acceptable fee rates. Mapping `fee_by_block_target` of `2`, `3`, `6`, `10` for `fastestFee`, `halfHourFee`, `hourFee` and `minimumFee` respectively. 
+- `/api/mempool-fees`: Mapping fee rates from mempool API:
+  - `fee_by_block_target[3]`: `fastestFee`
+  - `fee_by_block_target[6]`: `halfHourFee`
+  - `fee_by_block_target[8]`: `hourFee`
+  - `fee_by_block_target[10]`: `economyFee`
+  - `min_relay_feerate`: `minimumFee`
 
-- `/api/mempool-hill-fees`: Mapping fee rates from mempool.space to LND acceptable fee rates. The `fee_by_block_target[3]` and `min_relay_feerate` are fixed to `1012`, while `4`, `6`, `8`, `10` in the `fee_by_block_target` are mapped to `fastestFee`, `halfHourFee`, `hourFee` and `minimumFee` respectively.
+- `/api/mempool-hill-fees`: Mapping fee rates from mempool API, it aims to lower the commit_fee as low as possible, regardless of the actual mempool fee rates, when force-close happens, the participant can bump the transaction with a CPFP transaction:
+- `fee_by_block_target[3]`: `1012`
+  - `fee_by_block_target[4]`: `fastestFee`
+  - `fee_by_block_target[6]`: `halfHourFee`
+  - `fee_by_block_target[8]`: `hourFee`
+  - `fee_by_block_target[10]`: `economyFee`
+  - `min_relay_feerate`: `1012`
 
-- `/api/mempool-min-fees`: Mapping fee rates from mempool.space to LND acceptable fee rates, but all fees are equal the `minimumFee`, including the `min_relay_feerate`.
+- `/api/mempool-min-fees`: Mapping only the `minimalFee` from mempool API, it aims to give the commitment transaction a minimal chance to be pushed in the mempool:
+  - `fee_by_block_target[3]`: `minimumFee`
+  - `min_relay_feerate`: `minimumFee`
 
-- `/api/static-min-fees`: All fee rates are fixed to `1012`.
+- `/api/mempool-min-hill-fees`: Mapping fee rates from mempool API, it aims to provide a balance that the commit fee is not too low by using the `economyFee` as the commit fee rate, allowing force-close transactions to be stayed in the mempool without being purged immediately:
+  - `fee_by_block_target[3]`: `economyFee`
+  - `fee_by_block_target[4]`: `fastestFee`
+  - `fee_by_block_target[6]`: `halfHourFee`
+  - `fee_by_block_target[8]`: `hourFee`
+  - `fee_by_block_target[10]`: `economyFee`
+  - `min_relay_feerate`: `minimumFee`
+
+- `/api/mempool-custom-hill-fees`: Mapping fee rates from mempool API, it works exactly like the `mempool-min-hill-fees` by default, but you can pass `maxCommitFeeRate` to the querystring to limit the maximum commit fee rate:
+  - `fee_by_block_target[3]`: `min(economyFee, query.maxCommitFeeRate)`
+  - `fee_by_block_target[4]`: `fastestFee`
+  - `fee_by_block_target[6]`: `halfHourFee`
+  - `fee_by_block_target[8]`: `hourFee`
+  - `fee_by_block_target[10]`: `economyFee`
+  - `min_relay_feerate`: `min(minimumFee, query.maxCommitFeeRate)`
+
+- `/api/static-min-fees`: All fee rates are fixed to `1012`:
+  - `fee_by_block_target[3]`: `1012`
+  - `min_relay_feerate`: `1012`
 
 ## Apply fees
 

--- a/api/mempool-custom-hill-fees.ts
+++ b/api/mempool-custom-hill-fees.ts
@@ -1,0 +1,42 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { toMsatPerVb, MempoolService } from '../lib/mempool.js';
+import { z } from 'zod';
+
+const CustomHillFeesProps = z.object({
+  maxCommitFeeRate: z.coerce.number().positive().optional(),
+})
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  try {
+    const props = CustomHillFeesProps.parse(req.query);
+    const maxCommitFeeRate = props.maxCommitFeeRate ?? Number.MAX_VALUE;
+
+    const mempool = MempoolService.fromRequest(req);
+    const [fees, tipHash] = await Promise.all([
+      mempool.getFeesRecommended(),
+      mempool.getBlocksTipHash(),
+    ]);
+
+    console.log(`tip-hash: ${tipHash}, fees: ${JSON.stringify(fees)}`);
+
+    return res.json({
+      "current_block_hash": tipHash,
+      "fee_by_block_target": {
+        "3": toMsatPerVb(Math.min(fees.economyFee, maxCommitFeeRate)),
+        "4": toMsatPerVb(fees.fastestFee),
+        "6": toMsatPerVb(fees.halfHourFee),
+        "8": toMsatPerVb(fees.hourFee),
+        "10": toMsatPerVb(fees.economyFee),
+      },
+      "min_relay_feerate": toMsatPerVb(Math.min(fees.minimumFee, maxCommitFeeRate)),
+    });
+  } catch (e: any) {
+    res.status(500).send({
+      error: {
+        code: e?.code ?? e.status ?? null,
+        message: e?.message ?? 'internal server error',
+      },
+    });
+    throw e;
+  }
+}

--- a/api/mempool-custom-hill-fees.ts
+++ b/api/mempool-custom-hill-fees.ts
@@ -10,6 +10,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
     const props = CustomHillFeesProps.parse(req.query);
     const maxCommitFeeRate = props.maxCommitFeeRate ?? Number.MAX_VALUE;
+    console.log(`max-commit-fee-rate: ${maxCommitFeeRate}`);
 
     const mempool = MempoolService.fromRequest(req);
     const [fees, tipHash] = await Promise.all([


### PR DESCRIPTION
## Changes

- Add `mempool-custom-hill-fees` API for customizing the commit fee rate; it works exactly like the `mempool-min-hill-fees` by default, but you can pass `maxCommitFeeRate` to the querystring to limit the maximum commit fee rate
- Update `README.md` for the latest status of the APIs