### PR TITLE
refactor: replace "cell.mempool.space" with "mempool.space"

### DIFF
--- a/lib/mempool.ts
+++ b/lib/mempool.ts
@@ -9,7 +9,7 @@ export interface RecommendedFees extends FeesRecommended {
 }
 
 const MempoolProps = z.object({
-  url: z.string().default('https://cell.mempool.space'),
+  url: z.string().default('https://mempool.space'),
   network: z.enum(['mainnet', 'testnet', 'signet', 'testnet4']).default('testnet'),
 });
 


### PR DESCRIPTION
## Changes

- Replace `cell.mempool.space` with `mempool.space` as the default MempoolAPI URL